### PR TITLE
podman: Add WeeChat container image

### DIFF
--- a/opt/podman/weechat/Containerfile
+++ b/opt/podman/weechat/Containerfile
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: 2021-2025 Sébastien Helleu <flashcode@flashtux.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# WeeChat container based on Alpine
+#
+# Supported arguments:
+#    VERSION  WeeChat version (default: "latest" which is latest stable)
+#    SLIM     1 for a slim version (without plugins: script, scripts and spell)
+
+# ==== base for all stages ====
+
+FROM alpine:3.22 AS base
+LABEL stage=base
+
+LABEL maintainer="Sébastien Helleu <flashcode@flashtux.org>"
+
+# WeeChat version
+ARG VERSION="latest"
+ENV VERSION="${VERSION}"
+
+ARG SLIM=""
+ENV SLIM="${SLIM}"
+
+ARG HOME="/home/user"
+ENV HOME="${HOME}"
+
+ENV LANG="C.UTF-8"
+ENV TERM="xterm-256color"
+
+# create a user
+RUN set -eux ; \
+    adduser -D -h "$HOME" user ; \
+    mkdir -p "$HOME/.weechat" ; \
+    mkdir -p "$HOME/.config/weechat" ; \
+    mkdir -p "$HOME/.local/share/weechat" ; \
+    mkdir -p "$HOME/.cache/weechat" ; \
+    chown -R user:user "$HOME"
+
+# ==== build ====
+
+FROM base AS build
+LABEL stage=build
+
+RUN set -eux ; \
+    \
+    # install download/build dependencies
+    apk add --no-cache \
+        acl-dev \
+        asciidoctor \
+        cjson-dev \
+        cmake \
+        curl \
+        curl-dev \
+        g++ \
+        gcc \
+        gettext-dev \
+        gnupg \
+        gnutls-dev \
+        libgcrypt-dev \
+        make \
+        ncurses-dev \
+        pkgconf \
+        xz \
+        zlib-dev \
+        zstd-dev \
+    ; \
+    if [ -z "$SLIM" ] ; then \
+        apk add --no-cache \
+            argon2-dev \
+            aspell-dev \
+            guile-dev \
+            libxml2-dev \
+            lua5.4-dev \
+            perl-dev \
+            php83-dev \
+            php83-embed \
+            python3-dev \
+            ruby-dev \
+            tcl-dev \
+        ; \
+    fi ; \
+    \
+    # download WeeChat
+    cd /tmp ; \
+    curl -o weechat.tar.xz "https://weechat.org/files/src/weechat-${VERSION}.tar.xz" ; \
+    if [ "$VERSION" != "devel" ] ; then \
+        curl -o weechat.tar.xz.asc "https://weechat.org/files/src/weechat-${VERSION}.tar.xz.asc" ; \
+        export GNUPGHOME="$(mktemp -d)" ; \
+        gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys A9AB5AB778FA5C3522FD0378F82F4B16DEC408F8 ; \
+        gpg --batch --verify /tmp/weechat.tar.xz.asc /tmp/weechat.tar.xz ; \
+        gpgconf --kill all ; \
+    fi ; \
+    \
+    # build WeeChat
+    mkdir -p /tmp/weechat/build ; \
+    tar -xf /tmp/weechat.tar.xz -C /tmp/weechat --strip-components 1 ; \
+    cd /tmp/weechat/build ; \
+    if [ -z "$SLIM" ] ; then \
+        cmake \
+            .. \
+            -DCMAKE_INSTALL_PREFIX=/opt/weechat \
+            -DENABLE_MAN=ON \
+            -DENABLE_HEADLESS=ON \
+        ; \
+    else \
+        cmake \
+            .. \
+            -DCMAKE_INSTALL_PREFIX=/opt/weechat \
+            -DENABLE_MAN=ON \
+            -DENABLE_SCRIPT=OFF \
+            -DENABLE_SCRIPTS=OFF \
+            -DENABLE_SPELL=OFF \
+            -DENABLE_HEADLESS=ON \
+        ; \
+    fi ; \
+    make -j $(nproc) ; \
+    make install
+
+# ==== final image ====
+
+FROM base
+
+RUN set -eux ; \
+    \
+    # install runtime dependencies
+    apk add --no-cache \
+        ca-certificates \
+        cjson \
+        gettext \
+        gnutls \
+        libcurl \
+        libgcrypt \
+        ncurses-libs \
+        ncurses-terminfo \
+        tzdata \
+        zlib \
+        zstd \
+        zstd-libs \
+    ; \
+    if [ -z "$SLIM" ] ; then \
+        apk add --no-cache \
+            aspell-libs \
+            aspell-en \
+            guile \
+            guile-libs \
+            lua5.4-libs \
+            perl \
+            php83 \
+            php83-embed \
+            python3 \
+            ruby-libs \
+            tcl \
+        ; \
+    fi
+
+COPY --from=build /opt/weechat /opt/weechat
+
+RUN ln -sf /opt/weechat/bin/weechat /usr/bin/weechat
+RUN ln -sf /opt/weechat/bin/weechat-headless /usr/bin/weechat-headless
+
+WORKDIR $HOME
+
+USER user
+
+CMD ["weechat"]

--- a/opt/podman/weechat/README.md
+++ b/opt/podman/weechat/README.md
@@ -1,0 +1,93 @@
+# WeeChat container for Fedora Silverblue
+
+This repository contains the necessary files to run WeeChat as a Podman container on Fedora Silverblue.
+
+## Overview
+
+WeeChat is a fast, light, and extensible chat client. Running it as a container on Fedora Silverblue provides isolation and easy management.
+
+## Setup Instructions
+
+### 1. Build the Podman Image
+
+Build the WeeChat container image using the provided `Containerfile`:
+
+```bash
+podman build -t weechat .
+```
+
+#### Option A: Run as a Container
+
+1.**Run the container:**
+
+```bash
+mkdir -p ~/.local/podman/weechat/config ~/.local/podman/weechat/data ~/.local/podman/.weechat/cache
+podman run -it -d --name weechat -v $HOME/.local/podman/weechat:/home/user/.weechat:Z weechat
+```
+
+2.**Attach to the WeeChat container:**
+
+To interact with WeeChat, you need to attach to its console.
+
+```bash
+podman attach weechat
+```
+
+To detach without stopping WeeChat, press `Ctrl-a d`.
+
+3.**Stop the container:**
+
+```bash
+podman stop weechat
+```
+
+4.**Start the container again:**
+
+```bash
+podman start weechat
+```
+
+#### Option B: Run as a System Service (Recommended for persistent use)
+
+1.**Generate a systemd service file:**
+
+Podman can generate a systemd unit file for your container. This allows `systemd` to manage the container's lifecycle.
+
+```bash
+podman generate systemd --name weechat > ~/.config/systemd/user/weechat.service
+```
+
+2.**Reload systemd and enable the service:**
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now weechat.service
+```
+
+Now, WeeChat will start automatically when you log in.
+
+3.**Attach to the WeeChat session:**
+
+Since WeeChat is running in the background, you can attach to its session using `podman attach`.
+
+```bash
+podman attach weechat
+```
+
+To detach without stopping WeeChat, press `Ctrl-a d`.
+
+4.**Stop the service:**
+
+```bash
+systemctl --user stop weechat.service
+```
+
+5.**Start the service:**
+
+```bash
+systemctl --user start weechat.service
+```
+
+
+
+


### PR DESCRIPTION
Adds a multi-stage Containerfile for WeeChat, built on Alpine Linux. The image provides options for different WeeChat versions and a slim build without scripting language plugins.

Includes a README.md with detailed instructions for building and running the container on Fedora Silverblue, covering both direct Podman execution and systemd service integration for persistent use.